### PR TITLE
Nocturnal species list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ firstrun.ini
 HUMAN.txt
 include_species_list.txt
 /nbproject/private/
+nocturnal_species_list.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ apprise==1.9.0
 paho-mqtt<2.0.0
 pytest==7.1.2
 scikit-learn
-suntime
+suntime==1.2.5
 inotify
 requests
 matplotlib

--- a/scripts/backup_data.sh
+++ b/scripts/backup_data.sh
@@ -142,6 +142,7 @@ required=("/home/$BIRDNET_USER/BirdNET-Pi/birdnet.conf"
 optional=("/home/$BIRDNET_USER/BirdNET-Pi/apprise.txt"
 "/home/$BIRDNET_USER/BirdNET-Pi/scripts/blacklisted_images.txt"
 "/home/$BIRDNET_USER/BirdNET-Pi/scripts/disk_check_exclude.txt"
+"/home/$BIRDNET_USER/BirdNET-Pi/nocturnal_species_list.txt"
 "/home/$BIRDNET_USER/BirdNET-Pi/exclude_species_list.txt"
 "/home/$BIRDNET_USER/BirdNET-Pi/include_species_list.txt")
 

--- a/scripts/clear_all_data.sh
+++ b/scripts/clear_all_data.sh
@@ -25,6 +25,7 @@ echo "Re-creating necessary directories"
 sudo -u ${USER} ln -fs $(dirname $my_dir)/exclude_species_list.txt $my_dir
 sudo -u ${USER} ln -fs $(dirname $my_dir)/include_species_list.txt $my_dir
 sudo -u ${USER} ln -fs $(dirname $my_dir)/whitelist_species_list.txt $my_dir
+sudo -u ${USER} ln -fs $(dirname $my_dir)/nocturnal_species_list.txt $my_dir
 sudo -u ${USER} ln -fs $(dirname $my_dir)/homepage/* ${EXTRACTED}
 sudo -u ${USER} ln -fs $(dirname $my_dir)/model/labels.txt ${my_dir}
 sudo -u ${USER} ln -fs $my_dir ${EXTRACTED}

--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -67,6 +67,7 @@ create_necessary_dirs() {
   sudo -u ${USER} ln -fs $my_dir/exclude_species_list.txt $my_dir/scripts
   sudo -u ${USER} ln -fs $my_dir/include_species_list.txt $my_dir/scripts
   sudo -u ${USER} ln -fs $my_dir/whitelist_species_list.txt $my_dir/scripts
+  sudo -u ${USER} ln -fs $my_dir/nocturnal_species_list.txt $my_dir/scripts
   sudo -u ${USER} ln -fs $my_dir/homepage/* ${EXTRACTED}
   sudo -u ${USER} ln -fs $my_dir/model/labels.txt ${my_dir}/scripts
   sudo -u ${USER} ln -fs $my_dir/scripts ${EXTRACTED}

--- a/scripts/utils/helpers.py
+++ b/scripts/utils/helpers.py
@@ -7,6 +7,7 @@ from configparser import ConfigParser
 from itertools import chain
 
 from tzlocal import get_localzone
+from suntime import Sun
 
 _settings = None
 
@@ -107,3 +108,13 @@ def get_wav_files():
     open_recs = get_open_files_in_dir(rec_dir)
     files = [file for file in files if file not in open_recs]
     return files
+
+class LocationTime:
+    def __init__(self, lat, lon):
+        self.timezone = get_localzone()
+        self.sun = Sun(lat, lon)
+    def is_night(self, compare_time: datetime.datetime):
+        local_time = compare_time.astimezone(self.timezone)
+        sunrise_time = self.sun.get_sunrise_time(time_zone=self.timezone)
+        sunset_time = self.sun.get_sunset_time(time_zone=self.timezone)
+        return local_time < sunrise_time or local_time > sunset_time

--- a/scripts/utils/helpers.py
+++ b/scripts/utils/helpers.py
@@ -115,6 +115,6 @@ class LocationTime:
         self.sun = Sun(lat, lon)
     def is_night(self, compare_time: datetime.datetime):
         local_time = compare_time.astimezone(self.timezone)
-        sunrise_time = self.sun.get_sunrise_time(time_zone=self.timezone)
-        sunset_time = self.sun.get_sunset_time(time_zone=self.timezone)
+        sunrise_time = self.sun.get_local_sunrise_time(local_time.date())
+        sunset_time = self.sun.get_local_sunset_time(local_time.date())
         return local_time < sunrise_time or local_time > sunset_time


### PR DESCRIPTION
This PR replaces #1 which merge commit was accidentally deleted by a force push. It also includes a fix for [a bug in the suntime library](https://github.com/SatAgro/suntime/issues/30) which downgrades the library to version `1.2.5`.

### Original description

Adds a nocturnal species list in the fashion of the include and exclude species lists. A detection of a species in the nocturnal list will only be saved if it is currently night. Night is defined as after sunset and before sunrise based on the local time zone and coordinates of the site. The file path to the list is ~/BirdNET-Pi/nocturnal_species_list.txt. The list cannot be edited through the web interface.